### PR TITLE
Remove sdk download links from public documentation

### DIFF
--- a/monetization-sdk/desktop-mac-objective-c.mdx
+++ b/monetization-sdk/desktop-mac-objective-c.mdx
@@ -200,6 +200,6 @@ interface by calling this method or to the menu bar by toggling the
 
 The view controller with resource charts.
 
-[5]: https://downloads.joinmassive.com/sdk/macos/Massive%20SDK.dmg
+[5]: https://partners.joinmassive.com/sdk/downloads
 [6]: #api-reference
 [7]: #getting-started

--- a/monetization-sdk/desktop-mac-swift.mdx
+++ b/monetization-sdk/desktop-mac-swift.mdx
@@ -208,6 +208,6 @@ interface by calling this method or to the menu bar by toggling the
 
 The view controller with resource charts.
 
-[5]: https://downloads.joinmassive.com/sdk/macos/Massive%20SDK.dmg
+[5]: https://partners.joinmassive.com/sdk/downloads
 [6]: #api-reference
 [7]: #getting-started

--- a/monetization-sdk/desktop-windows.mdx
+++ b/monetization-sdk/desktop-windows.mdx
@@ -165,7 +165,7 @@ Starts a Massive node, pending user opt-in, attributed to your API token.
 
 **Parameters**
 
-**`apiToken`** A unique developer identifier obtained from this website.
+**`apiToken`** A unique developer identifier obtained from this the [applications](https://partners.joinmassive.com/sdk/applications) page.
 
 **`options`** Options for the Massive SDK initialization.
 
@@ -316,6 +316,6 @@ Sets a callback to be called when connection to the Massive is restored.
 
 Execution status code.
 
-[3]: https://downloads.joinmassive.com/sdk/windows/MassiveSDK.zip
+[3]: https://partners.joinmassive.com/sdk/downloads
 [6]: #api-reference
 [7]: #getting-started

--- a/monetization-sdk/mobile-android.mdx
+++ b/monetization-sdk/mobile-android.mdx
@@ -27,10 +27,10 @@ iconType: "brands"
 
 ### Sample application
 
-|                 |                                                      |                     |
-| ----------------| ---------------------------------------------------- | ------------------- |
-| <Icon icon="Android" iconType="solid" /> | Sample Application Kotlin (Android / FireOS) | [Download](https://downloads.joinmassive.com/sdk/android/1.4.0/Massive-SampleApp.zip) |
-| <Icon icon="Android" iconType="solid" /> | Sample Application Flutter (Android) | [Download](https://downloads.joinmassive.com/sdk/android/1.4.0/Massive-SampleAppFlutter.zip) |
+|                                          |                                              |                                                            |
+| ---------------------------------------- | -------------------------------------------- | ---------------------------------------------------------- |
+| <Icon icon="Android" iconType="solid" /> | Sample Application Kotlin (Android / FireOS) | [Download](https://partners.joinmassive.com/sdk/downloads) |
+| <Icon icon="Android" iconType="solid" /> | Sample Application Flutter (Android)         | [Download](https://partners.joinmassive.com/sdk/downloads) |
 
 
 Massive SDK comes with a sample application showing project configuration, API integration, and consent screen.
@@ -39,7 +39,7 @@ To run the app, follow next steps:
 
 1. Download the latest sample using the link above.
 2. Unarchive and open the project in Android Studio.
-3. Copy the API token from your [Profile](https://partners.joinmassive.com/profile).
+3. Copy the API token from the [applications](https://partners.joinmassive.com/sdk/applications) page.
 4. Set the token value to the variable `API_TOKEN` at the end of `MainActivity.kt`.
 5. Build and run a target `sampleapp`.
 
@@ -47,7 +47,7 @@ To run the app, follow next steps:
 
 Add the dependency to your project Gradle configuration:
 
-1. Add Massive maven repo `https://downloads.joinmassive.com/sdk/android/release` to the dependency `repositories` used by the project.
+1. Add Massive maven repository to the dependency `repositories` used by the project. You can find the URL in the [downloads](https://partners.joinmassive.com/sdk/downloads) page.
    It can be defined in different places depending on your project.
 
    Common places are:
@@ -63,7 +63,7 @@ Add the dependency to your project Gradle configuration:
             google()
             mavenCentral()
             maven {
-              url = uri("https://downloads.joinmassive.com/sdk/android/release")
+              url = uri("MASSIVE_MAVEN_REPO_URL")
             }
         }
     }
@@ -81,7 +81,7 @@ Add the dependency to your project Gradle configuration:
             google()
             mavenCentral()
             maven {
-                url uri("https://downloads.joinmassive.com/sdk/android/release")
+                url uri("MASSIVE_MAVEN_REPO_URL")
             }
         }
     }
@@ -137,7 +137,7 @@ Add the dependency to your project Gradle configuration:
 
 #### 1. Get the API token
 
-Massive SDK API token is available in your [Profile](https://partners.joinmassive.com/profile).
+Massive SDK API token is available in the [applications](https://partners.joinmassive.com/sdk/applications) page.
 
 #### 2. Initialize MassiveClient
 
@@ -274,7 +274,7 @@ The new version of the Massive SDK introduces several significant changes aimed 
   ```gradle
   repositories {
     maven {
-      url = uri("https://downloads.joinmassive.com/sdk/android/release")
+      url = uri("MASSIVE_MAVEN_REPO_URL")
     }
   }
   ```

--- a/monetization-sdk/mobile-ios.mdx
+++ b/monetization-sdk/mobile-ios.mdx
@@ -7,10 +7,10 @@ iconType: "brands"
 
 ## Latest release
 
-|                                        |                                    |         |                     |
-| ---------------------------------------| ---------------------------------- | ------- | ------------------- |
-| <Icon icon="apple" iconType="solid" /> | iOS SDK                            | `0.3.1` | [Download](https://downloads.joinmassive.com/sdk/ios/0.3.1/MassiveSDK-iOS-0.3.1.zip) |
-| <Icon icon="apple" iconType="solid" /> | Sample iPhone Application          | `0.3.1` | [Download](https://downloads.joinmassive.com/sdk/ios/0.3.1/MassiveSample-iPhoneAPP-0.3.1.zip) |
+|                                        |                           |                                                            |
+| ---------------------------------------| ------------------------- | ---------------------------------------------------------- |
+| <Icon icon="apple" iconType="solid" /> | iOS SDK                   | [Download](https://partners.joinmassive.com/sdk/downloads) |
+| <Icon icon="apple" iconType="solid" /> | Sample iPhone Application | [Download](https://partners.joinmassive.com/sdk/downloads) |
 
 ## Technical Requirements
 
@@ -39,7 +39,7 @@ Here's an example of how to integrate the Massive SDK into an iOS app. This samp
 
 #### 1. Obtain the API token
 
-Massive SDK API token is available in your [Profile](https://partners.joinmassive.com/profile).
+Massive SDK API token is available in the [applications](https://partners.joinmassive.com/sdk/applications) page.
 
 #### 2. Initialize MassiveClient
 

--- a/monetization-sdk/tv-fire.mdx
+++ b/monetization-sdk/tv-fire.mdx
@@ -27,9 +27,9 @@ iconType: "brands"
 
 ### Sample application
 
-|                 |                                                      |                     |
-| ----------------| ---------------------------------------------------- | ------------------- |
-| <Icon icon="Android" iconType="solid" /> | Sample Application (Android / Fire OS) | [Download](https://downloads.joinmassive.com/sdk/android/1.3.1/Massive-SampleApp.zip) |
+|                                          |                                        |                                                            |
+| ---------------------------------------- | -------------------------------------- | ---------------------------------------------------------- |
+| <Icon icon="Android" iconType="solid" /> | Sample Application (Android / Fire OS) | [Download](https://partners.joinmassive.com/sdk/downloads) |
 
 
 Massive SDK comes with a sample application showing project configuration, API integration, and consent screen.
@@ -38,7 +38,7 @@ To run the app, follow next steps:
 
 1. Download the latest sample using the link above.
 2. Unarchive and open the project in Android Studio.
-3. Copy the API token from your [Profile](https://partners.joinmassive.com/profile).
+3. Copy the API token from the [applications](https://partners.joinmassive.com/sdk/applications) page.
 4. Set the token value to the variable `API_TOKEN` at the end of `MainActivity.kt`.
 5. Build and run a target `sampleapp`.
 
@@ -46,7 +46,7 @@ To run the app, follow next steps:
 
 Add the dependency to your project Gradle configuration:
 
-1. Add Massive maven repo `https://downloads.joinmassive.com/sdk/android/release` to the dependency `repositories` used by the project.
+1. Add Massive maven repository to the dependency `repositories` used by the project. You can find the URL in the [downloads](https://partners.joinmassive.com/sdk/downloads) page.
    It can be defined in different places depending on your project.
 
    Common places are:
@@ -62,7 +62,7 @@ Add the dependency to your project Gradle configuration:
             google()
             mavenCentral()
             maven {
-              url = uri("https://downloads.joinmassive.com/sdk/android/release")
+              url = uri("MASSIVE_MAVEN_REPO_URL")
             }
         }
     }
@@ -80,7 +80,7 @@ Add the dependency to your project Gradle configuration:
             google()
             mavenCentral()
             maven {
-                url uri("https://downloads.joinmassive.com/sdk/android/release")
+                url uri("MASSIVE_MAVEN_REPO_URL")
             }
         }
     }
@@ -120,7 +120,7 @@ Add the dependency to your project Gradle configuration:
 
 #### 1. Get the API token
 
-Massive SDK API token is available in your [Profile](https://partners.joinmassive.com/profile).
+Massive SDK API token is available in the [applications](https://partners.joinmassive.com/sdk/applications) page.
 
 #### 2. Initialize MassiveClient
 
@@ -257,7 +257,7 @@ The new version of the Massive SDK introduces several significant changes aimed 
   ```gradle
   repositories {
     maven {
-      url = uri("https://downloads.joinmassive.com/sdk/android/release")
+      url = uri("MASSIVE_MAVEN_REPO_URL")
     }
   }
   ```


### PR DESCRIPTION
## Description

This pull request removes the SDK download links from the public documentation. After this change, the user must take the links from the partners portal, either from the downloads or the applications section.

## Summary of changes:

- Links to download artifacts now point to: https://partners.joinmassive.com/sdk/downloads
- Links to the API tokens now point to: https://partners.joinmassive.com/sdk/applications