### PR TITLE
feat: add robots noindex meta tag to prevent search engine indexing

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -30,6 +30,11 @@
     "name": "Dashboard",
     "url": "https://partners.joinmassive.com"
   },
+  "seo": {
+    "metatags": {
+      "robots": "noindex, nofollow"
+    }
+  },
   "primaryTab": {
     "name": "Residential"
   },


### PR DESCRIPTION
## Summary
- Added SEO configuration to mint.json with robots meta tag
- Configured "noindex, nofollow" directives to prevent search engine indexing
- Resolves Linear issue SUP-246: Remove docs.joinmassive.com from Google indexing

## Changes
- Added `seo.metatags.robots` configuration to `mint.json`
- This will add `<meta name="robots" content="noindex, nofollow">` to all pages

## Linear Issue
[SUP-246](https://linear.app/joinmassive/issue/SUP-246/meta-name=robots-content=noindex-nofollow-inside-a-head-tag-on-the)

## Test Plan
- [x] Deploy changes to staging/preview environment
- [x] Verify meta tag appears in page source: `<meta name="robots" content="noindex, nofollow">`
- [x] Confirm existing documentation functionality remains intact
- [ ] Test that search engines respect the noindex directive (may take time to verify)