### PR TITLE
Add norotate session mode to public docs

### DIFF
--- a/kb/technical/how-do-i-implement-sticky-sessions.mdx
+++ b/kb/technical/how-do-i-implement-sticky-sessions.mdx
@@ -23,7 +23,7 @@ Parameters Explained:
 - sessionmode-flex: Flexible session mode (also supports `strict` and `norotate`)
 - Port 65535: HTTPS (Use 65534 for HTTP, 65533 for SOCKS5)
 
-No-Rotate Example (fails with 502 instead of rotating):
+No-Rotate Example (returns 502/503 on node errors instead of rotating):
 
 ```bash
 curl -x https://network.joinmassive.com:65535 \

--- a/kb/technical/how-do-i-implement-sticky-sessions.mdx
+++ b/kb/technical/how-do-i-implement-sticky-sessions.mdx
@@ -20,5 +20,13 @@ Parameters Explained:
 
 - session-37: Unique session identifier
 - sessionttl-30: 30-minute session duration  
-- sessionmode-flex: Flexible session mode
+- sessionmode-flex: Flexible session mode (also supports `strict` and `norotate`)
 - Port 65535: HTTPS (Use 65534 for HTTP, 65533 for SOCKS5)
+
+No-Rotate Example (fails with 502 instead of rotating):
+
+```bash
+curl -x https://network.joinmassive.com:65535 \
+-U '{USERNAME}-session-37-sessionttl-30-sessionmode-norotate:{PASSWORD}' \
+https://cloudflare.com/cdn-cgi/trace
+```

--- a/kb/technical/how-do-i-implement-sticky-sessions.mdx
+++ b/kb/technical/how-do-i-implement-sticky-sessions.mdx
@@ -20,13 +20,5 @@ Parameters Explained:
 
 - session-37: Unique session identifier
 - sessionttl-30: 30-minute session duration  
-- sessionmode-flex: Flexible session mode (also supports `strict` and `norotate`)
+- sessionmode-flex: Flexible session mode
 - Port 65535: HTTPS (Use 65534 for HTTP, 65533 for SOCKS5)
-
-No-Rotate Example (returns 502/503 on node errors instead of rotating):
-
-```bash
-curl -x https://network.joinmassive.com:65535 \
--U '{USERNAME}-session-37-sessionttl-30-sessionmode-norotate:{PASSWORD}' \
-https://cloudflare.com/cdn-cgi/trace
-```

--- a/kb/technical/when-do-sticky-sessions-change-nodes.mdx
+++ b/kb/technical/when-do-sticky-sessions-change-nodes.mdx
@@ -10,4 +10,4 @@ Sessions may change under these conditions:
 4. Mode-specific conditions:
    - Flex Mode: After 15 consecutive errors
    - Strict Mode: Immediate change on failure
-   - No-Rotate Mode: Never changes nodes — returns 502 instead
+   - No-Rotate Mode: Never changes nodes — returns 502 (tunnel error) or 503 (node unavailable) instead

--- a/kb/technical/when-do-sticky-sessions-change-nodes.mdx
+++ b/kb/technical/when-do-sticky-sessions-change-nodes.mdx
@@ -10,4 +10,4 @@ Sessions may change under these conditions:
 4. Mode-specific conditions:
    - Flex Mode: After 15 consecutive errors
    - Strict Mode: Immediate change on failure
-   - No-Rotate Mode: Returns 502/503 instead of rotating (TTL expiry and rate limits still rotate)
+   - No-Rotate Mode: The node does not change until TTL expires

--- a/kb/technical/when-do-sticky-sessions-change-nodes.mdx
+++ b/kb/technical/when-do-sticky-sessions-change-nodes.mdx
@@ -10,3 +10,4 @@ Sessions may change under these conditions:
 4. Mode-specific conditions:
    - Flex Mode: After 15 consecutive errors
    - Strict Mode: Immediate change on failure
+   - No-Rotate Mode: Never changes nodes — returns 502 instead

--- a/kb/technical/when-do-sticky-sessions-change-nodes.mdx
+++ b/kb/technical/when-do-sticky-sessions-change-nodes.mdx
@@ -10,4 +10,4 @@ Sessions may change under these conditions:
 4. Mode-specific conditions:
    - Flex Mode: After 15 consecutive errors
    - Strict Mode: Immediate change on failure
-   - No-Rotate Mode: Never changes nodes — returns 502 (tunnel error) or 503 (node unavailable) instead
+   - No-Rotate Mode: Returns 502/503 instead of rotating (TTL expiry and rate limits still rotate)

--- a/residential/sticky-sessions.mdx
+++ b/residential/sticky-sessions.mdx
@@ -35,6 +35,7 @@ curl -x https://network.joinmassive.com:65535 \
 When a session identifier is specified and found, the server will perform a request via the same node unless:
 
 * TTL is expired (sessions expire exactly at creation time + TTL)
+ * The request limit per minute for the node is exceeded (only for strict mode)
 * The node has gone offline (except in norotate mode)
 * Error limit is reached (in flex mode)
 

--- a/residential/sticky-sessions.mdx
+++ b/residential/sticky-sessions.mdx
@@ -39,7 +39,7 @@ When a session identifier is specified and found, the server will perform a requ
 * The node has gone offline
 * Error limit is reached (in flex mode)
 
-If the session identifier is not found or the conditions above are not met, a new session is created with the specified ID and attached to a new node. In **norotate** mode, no new session is created — the request fails with a **502** error instead.
+If the session identifier is not found or the conditions above are not met, a new session is created with the specified ID and attached to a new node. In **norotate** mode, no new session is created — the request fails with a **502** or **503** error instead.
 
 ## Session Modes
 
@@ -89,10 +89,11 @@ curl -x https://network.joinmassive.com:65535 \
 
 ### No-Rotate Mode
 
-Sessions can operate in **norotate mode** where sessions are never rotated to a new node. If the assigned node becomes unavailable or any error occurs, the request fails with a **502** error instead of rotating to a new node. This is useful when IP consistency is critical and you would rather fail than silently switch IPs.
+Sessions can operate in **norotate mode** where sessions are never rotated to a new node. If the assigned node becomes unavailable or any error occurs, the request fails instead of rotating to a new node. This is useful when IP consistency is critical and you would rather fail than silently switch IPs.
 
 - Sessions never rotate to a new node
-- Returns **502** on node failure, TTL expiry, or rate limit instead of assigning a new node
+- Returns **502** on tunnel errors (node responds with an error) or **503** when the node is unavailable (gone offline or session expired)
+- The `sessionerr` parameter is ignored in norotate mode — any error fails immediately
 - Guarantees that a given session ID always maps to the same node or fails
 
 <Warning>
@@ -146,14 +147,15 @@ This example allows up to 5 consecutive errors before rotating to a new node.
 
   The following parameters are only applied when a session is created or rotated, not on existing sessions:
   - `sessionttl` - TTL duration
-  - `sessionmode` - Strict, flex, or norotate behavior
   - `sessionerr` - Error limit for flex mode
   - Geographic parameters (`subdivision`, `zipcode`, etc.)
 
   This means changing these parameters on subsequent requests with the same session ID will have no effect until the session rotates to a new node.
 
+  ### Parameters Re-parsed on Every Request
+
   <Warning>
-    **Runtime re-parsing:** Session parameters are re-parsed from the auth string on every request. If you omit a parameter like `sessionmode-norotate` on a subsequent request, the session silently reverts to the default behavior (strict mode). Always use consistent auth strings for all requests within a session.
+    **`sessionmode` is evaluated on every request**, not just at session creation. The mode is re-parsed from the auth string each time. If you omit `sessionmode-norotate` on a subsequent request, the session silently falls back to **strict** mode and may rotate on failure. Always use consistent auth strings for all requests within a session.
   </Warning>
 
   ### Session-Breaking Parameters

--- a/residential/sticky-sessions.mdx
+++ b/residential/sticky-sessions.mdx
@@ -39,7 +39,7 @@ When a session identifier is specified and found, the server will perform a requ
 * The node has gone offline
 * Error limit is reached (in flex mode)
 
-If the session identifier is not found or the conditions above are not met, a new session is created with the specified ID and attached to a new node. In **norotate** mode, no new session is created — the request fails with a **502** or **503** error instead.
+If the session identifier is not found or the conditions above are not met, a new session is created with the specified ID and attached to a new node. In **norotate** mode, the request fails instead of rotating (see [No-Rotate Mode](#no-rotate-mode) below).
 
 ## Session Modes
 
@@ -89,12 +89,10 @@ curl -x https://network.joinmassive.com:65535 \
 
 ### No-Rotate Mode
 
-Sessions can operate in **norotate mode** where sessions are never rotated to a new node. If the assigned node becomes unavailable or any error occurs, the request fails instead of rotating to a new node. This is useful when IP consistency is critical and you would rather fail than silently switch IPs.
+Sessions can operate in **norotate mode** where node errors cause immediate failure instead of rotation. This is useful when IP consistency is critical and you would rather fail than silently switch IPs. Note that TTL expiry and rate-limit exceeded still create a new session (same as other modes).
 
-- Sessions never rotate to a new node
-- Returns **502** on tunnel errors (node responds with an error) or **503** when the node is unavailable (gone offline or session expired)
+- Returns **502** on tunnel errors (node responds with an error) or **503** when the node has gone offline
 - The `sessionerr` parameter is ignored in norotate mode — any error fails immediately
-- Guarantees that a given session ID always maps to the same node or fails
 
 <Warning>
   **Consistent auth strings required:** Session parameters (including `sessionmode`) are re-parsed from the auth string on every request. If you omit `sessionmode-norotate` on a subsequent request using the same session ID, the session silently falls back to **strict** mode and may rotate to a new node on failure. Always include `sessionmode-norotate` in every request for the session.
@@ -105,14 +103,6 @@ Example with `sessionmode-norotate`:
 ```bash
 curl -x https://network.joinmassive.com:65535 \
      -U '{PROXY_USERNAME}-session-123-sessionmode-norotate:{API_KEY}' \
-     https://cloudflare.com/cdn-cgi/trace
-```
-
-Example combining norotate with a custom TTL:
-
-```bash
-curl -x https://network.joinmassive.com:65535 \
-     -U '{PROXY_USERNAME}-session-123-sessionmode-norotate-sessionttl-60:{API_KEY}' \
      https://cloudflare.com/cdn-cgi/trace
 ```
 
@@ -137,7 +127,7 @@ This example allows up to 5 consecutive errors before rotating to a new node.
 ## Best Practices
 
 1. **Plan TTL appropriately**: Since sessions use static TTL (not extended by activity), set an appropriate duration for your use case
-2. **Choose the right mode**: Default strict mode ensures immediate rotation on any error; use flex mode if you need IP stability; use norotate mode if you need guaranteed IP consistency and prefer failures over silent rotation
+2. **Choose the right mode**: Default strict mode ensures immediate rotation on any error; use flex mode if you need IP stability; use norotate mode if you need IP consistency on node errors (TTL expiry and rate limits still rotate)
 3. **Monitor error rates**: Adjust `sessionerr` based on your tolerance for retries (default is 15)
 4. **Session ID naming**: Use descriptive session IDs to help with debugging and monitoring
 
@@ -154,9 +144,7 @@ This example allows up to 5 consecutive errors before rotating to a new node.
 
   ### Parameters Re-parsed on Every Request
 
-  <Warning>
-    **`sessionmode` is evaluated on every request**, not just at session creation. The mode is re-parsed from the auth string each time. If you omit `sessionmode-norotate` on a subsequent request, the session silently falls back to **strict** mode and may rotate on failure. Always use consistent auth strings for all requests within a session.
-  </Warning>
+  `sessionmode` is evaluated on every request, not just at session creation (see the [norotate warning](#no-rotate-mode) above).
 
   ### Session-Breaking Parameters
 

--- a/residential/sticky-sessions.mdx
+++ b/residential/sticky-sessions.mdx
@@ -39,13 +39,13 @@ When a session identifier is specified and found, the server will perform a requ
 * The node has gone offline
 * Error limit is reached (in flex mode)
 
-If the session identifier is not found or the conditions above are not met, a new session is created with the specified ID and attached to a new node.
+If the session identifier is not found or the conditions above are not met, a new session is created with the specified ID and attached to a new node. In **norotate** mode, no new session is created — the request fails with a **502** error instead.
 
 ## Session Modes
 
 | Key         | Value            | Description |
 | ----------- | ---------------- | ----------- |
-| sessionmode | `strict`, `flex` | Controls session behavior on errors |
+| sessionmode | `strict`, `flex`, `norotate` | Controls session behavior on errors |
 
 ### Strict Mode (Default)
 
@@ -87,6 +87,34 @@ curl -x https://network.joinmassive.com:65535 \
      https://cloudflare.com/cdn-cgi/trace
 ```
 
+### No-Rotate Mode
+
+Sessions can operate in **norotate mode** where sessions are never rotated to a new node. If the assigned node becomes unavailable or any error occurs, the request fails with a **502** error instead of rotating to a new node. This is useful when IP consistency is critical and you would rather fail than silently switch IPs.
+
+- Sessions never rotate to a new node
+- Returns **502** on node failure, TTL expiry, or rate limit instead of assigning a new node
+- Guarantees that a given session ID always maps to the same node or fails
+
+<Warning>
+  **Consistent auth strings required:** Session parameters (including `sessionmode`) are re-parsed from the auth string on every request. If you omit `sessionmode-norotate` on a subsequent request using the same session ID, the session silently falls back to **strict** mode and may rotate to a new node on failure. Always include `sessionmode-norotate` in every request for the session.
+</Warning>
+
+Example with `sessionmode-norotate`:
+
+```bash
+curl -x https://network.joinmassive.com:65535 \
+     -U '{PROXY_USERNAME}-session-123-sessionmode-norotate:{API_KEY}' \
+     https://cloudflare.com/cdn-cgi/trace
+```
+
+Example combining norotate with a custom TTL:
+
+```bash
+curl -x https://network.joinmassive.com:65535 \
+     -U '{PROXY_USERNAME}-session-123-sessionmode-norotate-sessionttl-60:{API_KEY}' \
+     https://cloudflare.com/cdn-cgi/trace
+```
+
 ## Additional Parameters
 
 | Key         | Value            | Description | Default |
@@ -108,7 +136,7 @@ This example allows up to 5 consecutive errors before rotating to a new node.
 ## Best Practices
 
 1. **Plan TTL appropriately**: Since sessions use static TTL (not extended by activity), set an appropriate duration for your use case
-2. **Choose the right mode**: Default strict mode ensures immediate rotation on any error; use flex mode if you need IP stability
+2. **Choose the right mode**: Default strict mode ensures immediate rotation on any error; use flex mode if you need IP stability; use norotate mode if you need guaranteed IP consistency and prefer failures over silent rotation
 3. **Monitor error rates**: Adjust `sessionerr` based on your tolerance for retries (default is 15)
 4. **Session ID naming**: Use descriptive session IDs to help with debugging and monitoring
 
@@ -118,11 +146,15 @@ This example allows up to 5 consecutive errors before rotating to a new node.
 
   The following parameters are only applied when a session is created or rotated, not on existing sessions:
   - `sessionttl` - TTL duration
-  - `sessionmode` - Strict vs flex behavior
+  - `sessionmode` - Strict, flex, or norotate behavior
   - `sessionerr` - Error limit for flex mode
   - Geographic parameters (`subdivision`, `zipcode`, etc.)
 
   This means changing these parameters on subsequent requests with the same session ID will have no effect until the session rotates to a new node.
+
+  <Warning>
+    **Runtime re-parsing:** Session parameters are re-parsed from the auth string on every request. If you omit a parameter like `sessionmode-norotate` on a subsequent request, the session silently reverts to the default behavior (strict mode). Always use consistent auth strings for all requests within a session.
+  </Warning>
 
   ### Session-Breaking Parameters
 

--- a/residential/sticky-sessions.mdx
+++ b/residential/sticky-sessions.mdx
@@ -35,7 +35,7 @@ curl -x https://network.joinmassive.com:65535 \
 When a session identifier is specified and found, the server will perform a request via the same node unless:
 
 * TTL is expired (sessions expire exactly at creation time + TTL)
- * The request limit per minute for the node is exceeded (only for strict mode)
+* The request limit per minute for the node is exceeded (only for strict mode)
 * The node has gone offline (except in norotate mode)
 * Error limit is reached (in flex mode)
 

--- a/residential/sticky-sessions.mdx
+++ b/residential/sticky-sessions.mdx
@@ -35,11 +35,10 @@ curl -x https://network.joinmassive.com:65535 \
 When a session identifier is specified and found, the server will perform a request via the same node unless:
 
 * TTL is expired (sessions expire exactly at creation time + TTL)
-* The request limit per minute for the node is exceeded
-* The node has gone offline
+* The node has gone offline (except in norotate mode)
 * Error limit is reached (in flex mode)
 
-If the session identifier is not found or the conditions above are not met, a new session is created with the specified ID and attached to a new node. In **norotate** mode, the request fails instead of rotating (see [No-Rotate Mode](#no-rotate-mode) below).
+If the session identifier is not found or the conditions above are not met, a new session is created with the specified ID and attached to a new node.
 
 ## Session Modes
 
@@ -89,7 +88,7 @@ curl -x https://network.joinmassive.com:65535 \
 
 ### No-Rotate Mode
 
-Sessions can operate in **norotate mode** where node errors cause immediate failure instead of rotation. This is useful when IP consistency is critical and you would rather fail than silently switch IPs. Note that TTL expiry and rate-limit exceeded still create a new session (same as other modes).
+Sessions can operate in **norotate mode** where node errors cause immediate failure instead of rotation. This is useful when IP consistency is critical and you would rather fail than silently switch IPs. Note that TTL expiry still creates a new session (same as other modes).
 
 - Returns **502** on tunnel errors (node responds with an error) or **503** when the node has gone offline
 - The `sessionerr` parameter is ignored in norotate mode — any error fails immediately
@@ -127,7 +126,7 @@ This example allows up to 5 consecutive errors before rotating to a new node.
 ## Best Practices
 
 1. **Plan TTL appropriately**: Since sessions use static TTL (not extended by activity), set an appropriate duration for your use case
-2. **Choose the right mode**: Default strict mode ensures immediate rotation on any error; use flex mode if you need IP stability; use norotate mode if you need IP consistency on node errors (TTL expiry and rate limits still rotate)
+2. **Choose the right mode**: Default strict mode ensures immediate rotation on any error; use flex mode if you need IP stability; use norotate mode if you need IP consistency on node errors (TTL expiry still rotates)
 3. **Monitor error rates**: Adjust `sessionerr` based on your tolerance for retries (default is 15)
 4. **Session ID naming**: Use descriptive session IDs to help with debugging and monitoring
 


### PR DESCRIPTION
## Summary

- Add `norotate` session mode documentation to sticky sessions page, including behavior description, warnings about auth string re-parsing, and curl examples
- Update KB article "When do sticky sessions change nodes?" with norotate mode behavior (returns 502 instead of rotating)
- Update KB article "How do I implement sticky sessions?" with norotate example and updated parameter notes

## Related

PROXY-263 / PR #601

## Test plan

- [ ] Verify rendered MDX formatting for Warning/Info blocks in sticky-sessions.mdx
- [ ] Confirm all three session modes (`strict`, `flex`, `norotate`) are consistently referenced across all three files
- [ ] Review curl examples for correctness