### PR TITLE
PROXY-309: Update reseller-api docs with new proxy_access field

### DIFF
--- a/reseller-api-reference/reseller-api.json
+++ b/reseller-api-reference/reseller-api.json
@@ -731,6 +731,11 @@
               "type": "boolean",
               "description": "If true, synchronize the new account's domains blocklist with the parent account. The sub-account can still have its own blocklist entries, which are merged with the parent's.",
               "example": false
+            },
+            "proxy_access": {
+              "type": "boolean",
+              "description": "Whether the account currently has proxy access. Reflects the actual proxy status from the network layer, which may differ from account `status` if access was not revoked by user (e.g. usage limit reached).",
+              "example": true
             }
           }
         },


### PR DESCRIPTION
## Description

Updates the Reseller API JSON reference (`reseller-api-reference/reseller-api.json`) to document the new `proxy_access` boolean field on the `account` schema. This field reflects the actual proxy network access status of a subaccount and may differ from `status` when access has been revoked externally (e.g. usage limit reached via ETL).

## Changes

- `docs`: Added `proxy_access` boolean property to the `account` schema in `reseller-api-reference/reseller-api.json`

## Related changes

- Backend change introducing the field: https://github.com/magicinternet/massivebackend/pull/239
- Infrastructure OpenAPI spec update: https://github.com/magicinternet/infrastructure/pull/667
- Portal V1 changes: https://github.com/magicinternet/massivedevelopers/pull/823
- Portal V2 changes: https://github.com/magicinternet/partners-portal/pull/91

## How Has This Been Tested?

- JSON structure validated — no syntax errors
- Description and example value match the backend implementation and the YAML spec in the infrastructure repo
