### PR TITLE
docs(nav): add redirect for bare /unblocker path

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -16,6 +16,10 @@
   "openapi": ["web-render/openapi.json"],
   "redirects": [
     {
+      "source": "/unblocker",
+      "destination": "/web-render/ai"
+    },
+    {
       "source": "/unblocker/ai",
       "destination": "/web-render/ai"
     },


### PR DESCRIPTION
## Summary
Follow-up to [#36](https://github.com/joinmassive/docs/pull/36). Adds one redirect entry for the bare `/unblocker` path, which currently 404s.

## Why
Verified live (no auth):
- `/unblocker` → **404** (gap)
- `/unblocker/ai` → 308 → `/web-render/ai` ✓ (covered by #36)
- `/web-render` → 307 → `/web-render/ai` ✓ (Mintlify default tab behavior)

The bare URL was the one used by the portal's old "View API Docs →" button (before [magicinternet/partners-portal#109](https://github.com/magicinternet/partners-portal/pull/109)) and may appear in external references I can't grep.

## Destination choice
Redirects to `/web-render/ai` directly (the first tab page, which is what `/web-render` bare auto-resolves to) — saves a redirect hop versus pointing at `/web-render`.

## Test plan
- [ ] After merge + deploy, `curl -sIL https://docs.joinmassive.com/unblocker | grep -iE 'HTTP|location'` returns a 308 → /web-render/ai → 200
- [ ] Existing `/unblocker/*` redirects unaffected (spot-check one)
- [ ] Other tabs unaffected