### PR TITLE
[PORTAL-172] Swap API host to render.joinmassive.com

### DIFF
--- a/.github/workflows/sync-whitelabel.yml
+++ b/.github/workflows/sync-whitelabel.yml
@@ -35,7 +35,7 @@ jobs:
             --path 'web-render' \
             --company 'Massive' \
             --email 'support@joinmassive.com' \
-            --endpoint 'unblocker.joinmassive.com' \
+            --endpoint 'render.joinmassive.com' \
             --dashboard 'https://partners.joinmassive.com' \
             --checkout 'https://partners.joinmassive.com'
 

--- a/snippets/whitelabel/ai/device.mdx
+++ b/snippets/whitelabel/ai/device.mdx
@@ -1,6 +1,6 @@
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/ai'\
+'https://render.joinmassive.com/ai'\
 '?prompt=what+happened+to+blackberry'\
 '&device=blackberry+playbook'
 ```

--- a/snippets/whitelabel/ai/devices.mdx
+++ b/snippets/whitelabel/ai/devices.mdx
@@ -1,4 +1,4 @@
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/ai/devices'
+'https://render.joinmassive.com/ai/devices'
 ```

--- a/snippets/whitelabel/ai/expiration.mdx
+++ b/snippets/whitelabel/ai/expiration.mdx
@@ -2,7 +2,7 @@
 
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/ai'\
+'https://render.joinmassive.com/ai'\
 '?prompt=current+weather'\
 '&expiration=0'
 ```

--- a/snippets/whitelabel/ai/id.mdx
+++ b/snippets/whitelabel/ai/id.mdx
@@ -1,5 +1,5 @@
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/ai/completions'\
+'https://render.joinmassive.com/ai/completions'\
 '?id=1851dab8-4619-409f-893f-47dd3a180bc3'
 ```

--- a/snippets/whitelabel/ai/mode.mdx
+++ b/snippets/whitelabel/ai/mode.mdx
@@ -1,6 +1,6 @@
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/ai'\
+'https://render.joinmassive.com/ai'\
 '?prompt=prolonged+fasting'\
 '&mode=async'
 ```

--- a/snippets/whitelabel/ai/prompt.mdx
+++ b/snippets/whitelabel/ai/prompt.mdx
@@ -1,6 +1,6 @@
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/ai'\
+'https://render.joinmassive.com/ai'\
 '?prompt=best+basketball+shoes+for+2026'\
 '&country=us'\
 '&city=Portland'

--- a/snippets/whitelabel/ai/subdivision.mdx
+++ b/snippets/whitelabel/ai/subdivision.mdx
@@ -1,6 +1,6 @@
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/ai'\
+'https://render.joinmassive.com/ai'\
 '?prompt=find+vintage+guitar+stores'\
 '&country=us'\
 '&subdivision=tn'

--- a/snippets/whitelabel/browser/city.mdx
+++ b/snippets/whitelabel/browser/city.mdx
@@ -1,6 +1,6 @@
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/browser'\
+'https://render.joinmassive.com/browser'\
 '?url=https://guitars.com/'\
 '&country=us'\
 '&city=Nashville'

--- a/snippets/whitelabel/browser/device.mdx
+++ b/snippets/whitelabel/browser/device.mdx
@@ -1,6 +1,6 @@
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/browser'\
+'https://render.joinmassive.com/browser'\
 '?url=https://crackberry.com/'\
 '&device=blackberry+playbook'
 ```

--- a/snippets/whitelabel/browser/devices.mdx
+++ b/snippets/whitelabel/browser/devices.mdx
@@ -1,4 +1,4 @@
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/browser/devices'
+'https://render.joinmassive.com/browser/devices'
 ```

--- a/snippets/whitelabel/browser/expiration.mdx
+++ b/snippets/whitelabel/browser/expiration.mdx
@@ -2,7 +2,7 @@
 
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/browser'\
+'https://render.joinmassive.com/browser'\
 '?url=https://api.weather.gov/alerts'\
 '&expiration=0'
 ```

--- a/snippets/whitelabel/browser/id.mdx
+++ b/snippets/whitelabel/browser/id.mdx
@@ -1,5 +1,5 @@
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/browser/content'\
+'https://render.joinmassive.com/browser/content'\
 '?id=21cb972e-0e0f-47bb-9ce9-65b99e9cee77'
 ```

--- a/snippets/whitelabel/browser/mode.mdx
+++ b/snippets/whitelabel/browser/mode.mdx
@@ -1,6 +1,6 @@
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/browser'\
+'https://render.joinmassive.com/browser'\
 '?url=https://pubmed.ncbi.nlm.nih.gov/?term=prolonged+fasting'\
 '&mode=async'
 ```

--- a/snippets/whitelabel/browser/session.mdx
+++ b/snippets/whitelabel/browser/session.mdx
@@ -1,6 +1,6 @@
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
 -H 'Cookie: session=12345' \
-'https://unblocker.joinmassive.com/browser'\
+'https://render.joinmassive.com/browser'\
 '?url=https://www.amazon.com/s?k=luggage'
 ```

--- a/snippets/whitelabel/browser/url.mdx
+++ b/snippets/whitelabel/browser/url.mdx
@@ -1,5 +1,5 @@
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/browser'\
+'https://render.joinmassive.com/browser'\
 '?url=https://example.com/'
 ```

--- a/snippets/whitelabel/config.mdx
+++ b/snippets/whitelabel/config.mdx
@@ -1,5 +1,5 @@
 export const companyName = 'Massive';
 export const emailAddress = 'support@joinmassive.com';
-export const apiEndpoint = 'unblocker.joinmassive.com';
+export const apiEndpoint = 'render.joinmassive.com';
 export const dashboardUrl = 'https://partners.joinmassive.com';
 export const checkoutUrl = 'https://partners.joinmassive.com';

--- a/snippets/whitelabel/search/awaiting.mdx
+++ b/snippets/whitelabel/search/awaiting.mdx
@@ -2,7 +2,7 @@
 
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/search'\
+'https://render.joinmassive.com/search'\
 '?terms=how+tall+is+mount+everest'\
 '&awaiting=ai'\
 '&awaiting=answers'

--- a/snippets/whitelabel/search/country.mdx
+++ b/snippets/whitelabel/search/country.mdx
@@ -1,6 +1,6 @@
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/search'\
+'https://render.joinmassive.com/search'\
 '?terms=musical+instruments'\
 '&country=us'
 ```

--- a/snippets/whitelabel/search/id.mdx
+++ b/snippets/whitelabel/search/id.mdx
@@ -1,5 +1,5 @@
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/search/results'\
+'https://render.joinmassive.com/search/results'\
 '?id=078fd246-f0f7-44a0-aabb-cadd7b12454f'
 ```

--- a/snippets/whitelabel/search/mode.mdx
+++ b/snippets/whitelabel/search/mode.mdx
@@ -1,6 +1,6 @@
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/search'\
+'https://render.joinmassive.com/search'\
 '?terms=prolonged+fasting'\
 '&mode=async'
 ```

--- a/snippets/whitelabel/search/offset.mdx
+++ b/snippets/whitelabel/search/offset.mdx
@@ -2,7 +2,7 @@
 
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/search'\
+'https://render.joinmassive.com/search'\
 '?terms=vpn+comparison'\
 '&size=100'\
 '&offset=20'

--- a/snippets/whitelabel/search/subaccount.mdx
+++ b/snippets/whitelabel/search/subaccount.mdx
@@ -2,7 +2,7 @@
 
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/search'\
+'https://render.joinmassive.com/search'\
 '?terms=jargon+file'\
 '&subaccount=fubarco+systems'
 ```

--- a/snippets/whitelabel/search/terms.mdx
+++ b/snippets/whitelabel/search/terms.mdx
@@ -1,5 +1,5 @@
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/search'\
+'https://render.joinmassive.com/search'\
 '?terms=foo+bar+baz'
 ```

--- a/snippets/whitelabel/usage/dates.mdx
+++ b/snippets/whitelabel/usage/dates.mdx
@@ -1,6 +1,6 @@
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/usage'\
+'https://render.joinmassive.com/usage'\
 '?from=2025-12-24'\
 '&to=2025-12-25'
 ```

--- a/snippets/whitelabel/usage/datetimes.mdx
+++ b/snippets/whitelabel/usage/datetimes.mdx
@@ -1,6 +1,6 @@
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/usage'\
+'https://render.joinmassive.com/usage'\
 '?from=2025-12-24T18:00:00-06:00'\
 '&to=2025-12-25T9:00:00-06:00'
 ```

--- a/snippets/whitelabel/usage/emails.mdx
+++ b/snippets/whitelabel/usage/emails.mdx
@@ -2,7 +2,7 @@
 
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/usage'\
+'https://render.joinmassive.com/usage'\
 '?from=2025-12-24'\
 '&to=2025-12-25'\
 '&email=alice@example.com'\

--- a/snippets/whitelabel/usage/hour.mdx
+++ b/snippets/whitelabel/usage/hour.mdx
@@ -1,6 +1,6 @@
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/usage'\
+'https://render.joinmassive.com/usage'\
 '?from=2025-12-24'\
 '&to=2025-12-25'\
 '&by=hour'

--- a/snippets/whitelabel/usage/service.mdx
+++ b/snippets/whitelabel/usage/service.mdx
@@ -1,6 +1,6 @@
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/usage'\
+'https://render.joinmassive.com/usage'\
 '?from=2025-12-24'\
 '&to=2025-12-25'\
 '&service=search'

--- a/snippets/whitelabel/usage/services.mdx
+++ b/snippets/whitelabel/usage/services.mdx
@@ -1,6 +1,6 @@
 ```shell
 curl -H "Authorization: Bearer $MASSIVE_TOKEN" \
-'https://unblocker.joinmassive.com/usage'\
+'https://render.joinmassive.com/usage'\
 '?from=2025-12-24'\
 '&to=2025-12-25'\
 '&service=search'\

--- a/web-render/openapi.json
+++ b/web-render/openapi.json
@@ -5,7 +5,7 @@
     "description": "The missing services for agent-first development.",
     "version": "1.0.0"
   },
-  "servers": [{ "url": "https://unblocker.joinmassive.com" }],
+  "servers": [{ "url": "https://render.joinmassive.com" }],
   "security": [{ "bearerAuth": [] }],
   "paths": {
     "/search": {


### PR DESCRIPTION
## Summary

Phase 2 of the Web Render API rename ([PORTAL-172](https://linear.app/joinmassive/issue/PORTAL-172/update-product-naming) section 1): swaps the customer-facing API host in all docs surfaces from `unblocker.joinmassive.com` to `render.joinmassive.com`.

Brian (AgentFirst) confirmed the new host is provisioned and ready (2026-04-23 in #prd-unblocker). The old host stays live as an alias indefinitely, so existing customers are not broken.

## Changes
- `web-render/openapi.json` — `servers[0].url`
- `snippets/whitelabel/**/*.mdx` — 30 example curls regenerated by upstream
- `.github/workflows/sync-whitelabel.yml` — `--endpoint` arg, so the weekly sync re-renders snippets with the new host (otherwise next run would silently revert all curl examples)

## Test plan
- [ ] Mintlify preview shows `render.joinmassive.com` in: Web Render API page (servers), every snippet, openapi spec
- [ ] Bare `/unblocker` and `/unblocker/*` redirects still work (untouched in this PR)
- [ ] Manually trigger `Sync AgentFirst whitelabel docs` workflow after merge — confirm next sync PR (if any) still uses `render.joinmassive.com`