### PR TITLE
feat: reporting-api group_by description

### DIFF
--- a/reporting-api-reference/Massive-Proxy-Reporting-API-v1.yaml
+++ b/reporting-api-reference/Massive-Proxy-Reporting-API-v1.yaml
@@ -45,6 +45,15 @@ paths:
 
             Accepted formats: date, RFC3339.
           example: "2025-01-01 or 2025-01-01T10:00:00Z"
+        - in: query
+          name: group_by
+          schema:
+            type: string
+          required: false
+          description: |
+            Group usage data by the specified dimension.
+
+            When set to `subaccount`, returns usage broken down by sub-account with an additional `username` field in each record.
       responses:
         "200":
           description: Successfully retrieved usage
@@ -54,6 +63,27 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/UsageRecord"
+              examples:
+                default:
+                  summary: Default usage
+                  value:
+                    - date: "2025-01-01"
+                      total: 1000
+                      successful: 500
+                      used_bytes: 123456789
+                grouped_by_subaccount:
+                  summary: Grouped by sub-account
+                  value:
+                    - date: "2025-01-01"
+                      username: "user1_sub1"
+                      total: 800
+                      successful: 400
+                      used_bytes: 98765432
+                    - date: "2025-01-01"
+                      username: "user1_sub2"
+                      total: 200
+                      successful: 100
+                      used_bytes: 24691357
         "400":
           $ref: "#/components/responses/BadRequestError"
         "407":
@@ -75,6 +105,9 @@ components:
           type: string
           description: Date for usage data
           example: "2025-01-01"
+        username:
+          type: string
+          description: Sub-account proxy username. Only present when `group_by=subaccount`.
         total:
           type: number
           description: Total number of connections


### PR DESCRIPTION
## Description

Document the new `group_by` query parameter for the Proxy Reporting API `GET /v1/usage` endpoint. When set to `subaccount`, the response includes usage broken down by sub-account with an additional `username` field in each record.

## Changes

- feature: Add `group_by` query parameter definition to the OpenAPI spec
- feature: Add `username` field to the `UsageRecord` schema (present only when `group_by=subaccount`)
- feature: Add named response examples ("Default usage" and "Grouped by sub-account") for clearer API documentation

## Related changes

- Backend implementation: `massivebackend` handler at `lambdas/proxy/reporting/internal/api/handler.go` (already merged)

## How Has This Been Tested?

Ran `mintlify dev` locally and verified:
- The `group_by` parameter renders correctly as a string field with description
- The response examples panel shows both "Default usage" (without `username`) and "Grouped by sub-account" (with `username`) as selectable options
- No OpenAPI validation errors related to the reporting spec