### PR TITLE
[PORTAL-225] Remove /ai/completions from Web Render docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -202,7 +202,6 @@
             "group": "API Reference",
             "pages": [
               "web-render/reference/ai",
-              "web-render/reference/ai/completions",
               "web-render/reference/ai/devices",
               "web-render/reference/browser",
               "web-render/reference/browser/content",

--- a/web-render/reference/ai/completions.mdx
+++ b/web-render/reference/ai/completions.mdx
@@ -1,3 +1,0 @@
----
-openapi: get /ai/completions
----


### PR DESCRIPTION
## Summary

- Drop `/ai/completions` entry from the API Reference sidebar in `docs.json`
- Delete the now-orphaned `web-render/reference/ai/completions.mdx` page (already removed upstream in `agentfirstdev/whitelabel`, so the next scheduled sync would have done this anyway)

## Context

Brian in [#prd-render 2026-05-06 12:37 CEST](https://magicinternet.slack.com/archives/C09SRNVFGAG/p1778063832631239?thread_ts=1778063832.631239&cid=C09SRNVFGAG):
> doc is ready to be updated - make sure to remove link to `/ai/completions` from `docs.json` (that's the endpoint vova found that's not supported yet and i temporarily removed the associated page)

Linear: [PORTAL-225](https://linear.app/joinmassive/issue/PORTAL-225/remove-aicompletions-endpoint-link-from-portal-docsjson)

## Test plan
- [ ] Mintlify preview renders without the `/ai/completions` entry in the API Reference sidebar
- [ ] Direct nav to `/web-render/reference/ai/completions` returns Mintlify's 'page not found' (expected)
- [ ] Existing `/unblocker/reference/ai/completions` redirect still works mechanically (it'll now resolve to the same 'not found' — acceptable, harmless until Brian re-adds the endpoint)