### PR TITLE
[MASS-732] docs: fix /residential/sample-integrations 404

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -138,6 +138,7 @@
           {
             "group": "Sample Integrations",
             "pages": [
+              "residential/sample-integrations",
               "residential/samples/puppeteer",
               "residential/samples/python",
               "residential/samples/scrapy",

--- a/residential/sample-integrations.mdx
+++ b/residential/sample-integrations.mdx
@@ -1,0 +1,62 @@
+---
+title: 'Choose Your Language or Tool'
+description: 'Pick your language, framework, or tool and start sending traffic through the Massive Network in minutes.'
+---
+
+<CardGroup cols={2}>
+  <Card
+    title="Puppeteer"
+    icon="ghost"
+    href="/residential/samples/puppeteer"
+  >
+    Browser automation in Node.js with `--proxy-server` and `page.authenticate`.
+  </Card>
+
+  <Card
+    title="Python"
+    icon="python"
+    href="/residential/samples/python"
+  >
+    Send requests through the network with the `requests` library.
+  </Card>
+
+  <Card
+    title="Scrapy"
+    icon="spider"
+    href="/residential/samples/scrapy"
+  >
+    Route Scrapy spiders through the network using the `proxy` meta field.
+  </Card>
+
+  <Card
+    title="Ruby"
+    icon="gem"
+    href="/residential/samples/ruby"
+  >
+    Use `Net::HTTP` to proxy Ruby requests through the network.
+  </Card>
+
+  <Card
+    title=".NET (C#)"
+    icon="microsoft"
+    href="/residential/samples/.net"
+  >
+    Configure `HttpClient` with `WebProxy` and `NetworkCredential`.
+  </Card>
+
+  <Card
+    title="SwitchyOmega"
+    icon="browser"
+    href="/residential/samples/switchyomega"
+  >
+    Configure the SwitchyOmega browser extension to use Massive proxies.
+  </Card>
+
+  <Card
+    title="FoxyProxy"
+    icon="firefox-browser"
+    href="/residential/samples/foxyproxy"
+  >
+    Configure the FoxyProxy browser extension to use Massive proxies.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary
- Adds new aggregator page at `/residential/sample-integrations` linking to all 7 existing samples as cards (Puppeteer, Python, Scrapy, Ruby, .NET, SwitchyOmega, FoxyProxy), modeled on the SDK's platform-select pages
- Registers it as the first entry in the Sample Integrations group in `docs.json` so the previously 404'd URL resolves to a clean directory of options

Fixes [MASS-732](https://linear.app/joinmassive/issue/MASS-732/fix-broken-sample-integrations-link-in-public-docs-404).

## Test plan
- [x] `mintlify dev` — visit `/residential/sample-integrations` and verify the page renders with 7 cards
- [x] Each card links to its sample page
- [x] Sidebar nav shows the new page first under "Sample Integrations"

🤖 Generated with [Claude Code](https://claude.com/claude-code)