### PR TITLE
docs(device-type): document multi-value type targeting

### DIFF
--- a/residential/device-type-targeting.mdx
+++ b/residential/device-type-targeting.mdx
@@ -30,3 +30,15 @@ curl -x https://network.joinmassive.com:65535 \
      -U '{PROXY_USERNAME}-type-mobile-country-US-subdivision-NY-session-1:{API_KEY}' \
      https://cloudflare.com/cdn-cgi/trace
 ```
+
+## Multiple device types
+
+Provide a comma-separated list to match **any** of several device types. The following request targets a mobile **or** tv node in the US:
+
+```bash
+curl -x https://network.joinmassive.com:65535 \
+     -U '{PROXY_USERNAME}-type-mobile,tv-country-US:{API_KEY}' \
+     https://cloudflare.com/cdn-cgi/trace
+```
+
+An unrecognized `type` value returns HTTP 400.


### PR DESCRIPTION
## What

Documents the comma-separated **multi-value `type` targeting** feature shipped in massiveproxy [PR #671](https://github.com/magicinternet/massiveproxy/pull/671).

Adds a **"Multiple device types"** section to `residential/device-type-targeting.mdx`:
- `type` now accepts a comma-separated list with **OR** matching (e.g. `type=mobile,tv` → a mobile **or** tv node)
- An unrecognized `type` value returns **HTTP 400** (was previously silently treated as "any")



