### PR TITLE
📝 docs(web-render): add overview/router landing page (RENDER-21)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -19,7 +19,7 @@
   "redirects": [
     {
       "source": "/unblocker",
-      "destination": "/web-render/ai"
+      "destination": "/web-render/overview"
     },
     {
       "source": "/unblocker/ai",
@@ -184,6 +184,12 @@
       {
         "tab": "Web Render API",
         "groups": [
+          {
+            "group": "Get started",
+            "pages": [
+              "web-render/overview"
+            ]
+          },
           {
             "group": "Endpoints",
             "pages": [

--- a/web-render/overview.mdx
+++ b/web-render/overview.mdx
@@ -5,7 +5,7 @@ iconType: light
 description: One API to chat with AI, browse, and search the live web.
 ---
 
-import { companyName, apiEndpoint } from '/snippets/whitelabel/config.mdx';
+import { companyName } from '/snippets/whitelabel/config.mdx';
 
 The **{companyName}** Web Render API turns hard-to-reach web content into clean, structured
 data. Every service shares one RESTful interface: authenticate with your API token, send a

--- a/web-render/overview.mdx
+++ b/web-render/overview.mdx
@@ -1,0 +1,56 @@
+---
+title: Overview
+icon: compass
+iconType: light
+description: One API to chat with AI, browse, and search the live web.
+---
+
+import { companyName, apiEndpoint } from '/snippets/whitelabel/config.mdx';
+
+The **{companyName}** Web Render API turns hard-to-reach web content into clean, structured
+data. Every service shares one RESTful interface: authenticate with your API token, send a
+`GET` request, and get back JSON, rendered HTML, or raw HTML. All requests go to
+**https://&zwj;{apiEndpoint}/**.
+
+## Endpoints
+
+<CardGroup cols={3}>
+  <Card title="AI chat" icon="message" href="/web-render/ai">
+    Generate popular LLM completions.
+  </Card>
+  <Card title="Browsing" icon="browser" href="/web-render/browser">
+    Unblock difficult-to-crawl websites.
+  </Card>
+  <Card title="Search" icon="magnifying-glass" href="/web-render/search">
+    Extract top real-time search results.
+  </Card>
+</CardGroup>
+
+## Configuration
+
+Options that apply across every endpoint.
+
+<CardGroup cols={2}>
+  <Card title="Geotargeting" icon="earth-americas" href="/web-render/geotargeting">
+    Make requests from anywhere.
+  </Card>
+  <Card title="Scheduling" icon="clock" href="/web-render/scheduling">
+    Defer responses for later retrieval.
+  </Card>
+</CardGroup>
+
+## Managing your account
+
+<CardGroup cols={2}>
+  <Card title="Pricing" icon="credit-card" href="/web-render/pricing">
+    Understand API credits and billing.
+  </Card>
+  <Card title="Reporting" icon="chart-line" href="/web-render/usage">
+    Track API usage and performance.
+  </Card>
+</CardGroup>
+
+## API reference
+
+Prefer to jump straight to the spec? The [API reference](/web-render/reference/ai) documents
+every parameter, response field, and status code for each endpoint.

--- a/web-render/overview.mdx
+++ b/web-render/overview.mdx
@@ -9,8 +9,7 @@ import { companyName, apiEndpoint } from '/snippets/whitelabel/config.mdx';
 
 The **{companyName}** Web Render API turns hard-to-reach web content into clean, structured
 data. Every service shares one RESTful interface: authenticate with your API token, send a
-`GET` request, and get back JSON, rendered HTML, or raw HTML. All requests go to
-**https://&zwj;{apiEndpoint}/**.
+`GET` request, and get back JSON, rendered HTML, or raw HTML.
 
 ## Endpoints
 


### PR DESCRIPTION
## Summary

Adds an overview/landing page for the Web Render API docs so visitors land on
an intro with a router to every endpoint, instead of dropping straight into the
AI chat page.

## Changes

- **New page** `web-render/overview.mdx` — a card-based router grouped into
  Endpoints (AI chat, Browsing, Search), Configuration (Geotargeting,
  Scheduling), and account management (Pricing, Reporting), plus a link into the
  API reference. Uses the whitelabel config snippet so it renders per brand.
- **Nav** (`docs.json`) — adds a "Get started" group with `overview` as the
  first entry in the Web Render API tab, making it the new landing page.