### PR TITLE
docs(reseller-api): document PUT /accounts/:id/session-limit

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -168,6 +168,7 @@
               "reseller-api-reference/disable-account",
               "reseller-api-reference/enable-account",
               "reseller-api-reference/update-domains-blocklist",
+              "reseller-api-reference/update-session-limit",
               "reseller-api-reference/allocate-traffic-for-an-account",
               "reseller-api-reference/get-account-usage",
               "reseller-api-reference/get-the-allocation-list"

--- a/reseller-api-reference/reseller-api.json
+++ b/reseller-api-reference/reseller-api.json
@@ -824,12 +824,12 @@
           "properties": {
             "session_traffic_limit": {
               "type": "string",
-              "description": "Per-session traffic ceiling: SI size string (\"250mb\" = 250×1000² bytes; not binary \"mib\") or raw byte count. `0` disables; a positive value is >= 1000 bytes.",
+              "description": "Per-session traffic ceiling: SI size string (\"250kb\", \"250mb\", \"250gb\") or raw byte count. `0` disables; a positive value is >= 1000 bytes.",
               "example": "250mb"
             },
             "session_duration_limit": {
               "type": "string",
-              "description": "Per-session duration ceiling as a Go duration (\"15m\", \"1h30m\"). `0`/`\"0s\"` disables; a positive value is >= 1s.",
+              "description": "Per-session duration ceiling as a duration (\"15m\", \"1h30m\"). `0`/`\"0s\"` disables; a positive value is >= 1s.",
               "example": "15m"
             }
           }

--- a/reseller-api-reference/reseller-api.json
+++ b/reseller-api-reference/reseller-api.json
@@ -6,7 +6,7 @@
         "url": "logo192.png",
         "altText": "Massive Proxy Resellers API"
       },
-      "description": "The Proxy Resellers API allows to manage proxy resellers accounts.\nThe accounts created via this API are used to authenticate the Network API (see below \"Using Credentials).\n\n## Features\n- Create an account\n- Update an account\n- Get list of accounts created\n- Enable/Disable account\n- Manage account domains blocklist\n- Allocate traffic for account\n- Get list of allocations made for account\n- Get current account traffic usage\n\n## Authorization\nThe API uses API key for authorization. The API key should be included in the request header as `x-api-key`.\n\nPlease note that the API key provided for the Network API is not automatically enabled for this API, enabling it must be requested to Massive support.\n\n## Using Credentials\nSuccessfully created account will have the following credentials to access the Massive Network:\n- Username: `<customerUsername>_<accountUsername>`\n- Password: `<accountPassword>`\n\n**The account will be linked to the customer but have own credentials to access the Massive Network.**\n\n### Example\nRequest:\n```sh\ncurl --location 'https://api-network.joinmassive.com/resellers/accounts' \\\n--header 'Content-Type: application/json' \\\n--header 'x-api-key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' \\\n--data-raw '{\n  \"username\": \"johndoe@example.com\",\n  \"password\": \"isdnf8eh8weun823\"\n}'\n```\n\nRequest to the Massive Network considering that x-api-key belongs to the demo@joinmassive.com account:\n```sh\ncurl -x 'https://network.joinmassive.com:65535' \\\n-U 'demo@joinmassive.com_johndoe@example.com:isdnf8eh8weun823'\n```\n\n_demo@joinmassive.com_johndoe@example.com_ is a username and targeting params can be provided according to the Massive Network documentation.\n",
+      "description": "The Proxy Resellers API allows to manage proxy resellers accounts.\nThe accounts created via this API are used to authenticate the Network API (see below \"Using Credentials).\n\n## Features\n- Create an account\n- Update an account\n- Get list of accounts created\n- Enable/Disable account\n- Manage account domains blocklist\n- Set per-session traffic/duration limits for a sub-account\n- Allocate traffic for account\n- Get list of allocations made for account\n- Get current account traffic usage\n\n## Authorization\nThe API uses API key for authorization. The API key should be included in the request header as `x-api-key`.\n\nPlease note that the API key provided for the Network API is not automatically enabled for this API, enabling it must be requested to Massive support.\n\n## Using Credentials\nSuccessfully created account will have the following credentials to access the Massive Network:\n- Username: `<customerUsername>_<accountUsername>`\n- Password: `<accountPassword>`\n\n**The account will be linked to the customer but have own credentials to access the Massive Network.**\n\n### Example\nRequest:\n```sh\ncurl --location 'https://api-network.joinmassive.com/resellers/accounts' \\\n--header 'Content-Type: application/json' \\\n--header 'x-api-key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' \\\n--data-raw '{\n  \"username\": \"johndoe@example.com\",\n  \"password\": \"isdnf8eh8weun823\"\n}'\n```\n\nRequest to the Massive Network considering that x-api-key belongs to the demo@joinmassive.com account:\n```sh\ncurl -x 'https://network.joinmassive.com:65535' \\\n-U 'demo@joinmassive.com_johndoe@example.com:isdnf8eh8weun823'\n```\n\n_demo@joinmassive.com_johndoe@example.com_ is a username and targeting params can be provided according to the Massive Network documentation.\n",
       "version": "v1"
     },
     "servers": [
@@ -411,6 +411,69 @@
           ]
         }
       },
+      "/accounts/{id}/session-limit": {
+        "put": {
+          "summary": "Update per-session limit for account",
+          "description": "Set the per-session traffic and/or duration ceiling for a sub-account. The proxy disconnects the session once it reaches either ceiling. Send one or both fields; an omitted field is left unchanged, `0` disables that ceiling.\n",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              },
+              "description": "The account ID"
+            }
+          ],
+          "security": [
+            {
+              "api-key": []
+            }
+          ],
+          "operationId": "updateSessionLimit",
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/updateSessionLimitRequest"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Session limit updated successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/updateSessionLimitResponse"
+                  }
+                }
+              }
+            },
+            "400": {
+              "$ref": "#/components/responses/BadRequestError"
+            },
+            "401": {
+              "$ref": "#/components/responses/UnauthorizedError"
+            },
+            "403": {
+              "$ref": "#/components/responses/ForbiddenError"
+            },
+            "404": {
+              "$ref": "#/components/responses/AccountNotFound"
+            },
+            "500": {
+              "$ref": "#/components/responses/InternalServerError"
+            }
+          },
+          "tags": [
+            "User profile Configuration"
+          ]
+        }
+      },
       "/accounts/{id}/usage": {
         "get": {
           "summary": "Get account usage",
@@ -751,6 +814,33 @@
               "description": "Array of domain names to block. Maximum 253 characters per domain. Domains will be automatically deduplicated and sanitized.",
               "example": ["example.com", "test.org", "badsite.net"],
               "maxItems": 100
+            }
+          }
+        },
+        "updateSessionLimitRequest": {
+          "type": "object",
+          "minProperties": 1,
+          "description": "At least one field is required.",
+          "properties": {
+            "session_traffic_limit": {
+              "type": "string",
+              "description": "Per-session traffic ceiling: SI size string (\"250mb\" = 250×1000² bytes; not binary \"mib\") or raw byte count. `0` disables; a positive value is >= 1000 bytes.",
+              "example": "250mb"
+            },
+            "session_duration_limit": {
+              "type": "string",
+              "description": "Per-session duration ceiling as a Go duration (\"15m\", \"1h30m\"). `0`/`\"0s\"` disables; a positive value is >= 1s.",
+              "example": "15m"
+            }
+          }
+        },
+        "updateSessionLimitResponse": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The account ID.",
+              "example": "acc_12345"
             }
           }
         }

--- a/reseller-api-reference/update-session-limit.mdx
+++ b/reseller-api-reference/update-session-limit.mdx
@@ -1,0 +1,7 @@
+---
+openapi: put /accounts/{id}/session-limit
+---
+
+<Note>
+  Applies to sub-accounts you own. Each ceiling has three states: omit the field to inherit the parent account's value, send `0` to disable it, or send a positive value to cap it. The proxy disconnects the session once it reaches either ceiling.
+</Note>


### PR DESCRIPTION
## What

Adds the reseller API reference for **`PUT /accounts/{id}/session-limit`** — set a per-session traffic and/or duration ceiling on a sub-account.

## Changes

- `reseller-api-reference/reseller-api.json` — OpenAPI path plus `updateSessionLimitRequest` / `updateSessionLimitResponse` schemas, and the endpoint added to the API "Features" list.
- `reseller-api-reference/update-session-limit.mdx` — reference page with a note on the three states: omit a field to inherit the parent account's value, send `0` to disable it, or a positive value to cap it.
- `docs.json` — navigation entry.

## Field formats

- `session_traffic_limit` — SI size string (`"250mb"`, decimal; not binary `"mib"`) or a byte number. `0` disables; a positive value is >= 1000 bytes.
- `session_duration_limit` — duration string (`"15m"`, `"1h30m"`). `0` disables; a positive value is >= 1s.

## Note

Please hold merge until the endpoint is live in production.