### PR TITLE
docs: link to Blocked Destination Categories across restriction pages

### DIFF
--- a/isp-proxies/usage-restrictions.mdx
+++ b/isp-proxies/usage-restrictions.mdx
@@ -8,7 +8,7 @@ description: 'Some limitations apply to HTTP and SOCKS5 endpoints for ISP proxie
 - **Limited Ports:** Only standard ports (80, 443) are available.
     - Allowed: `http://example.com/`, `https://example.com/`
     - Not Allowed: `http://example.com:8080`
-- **Content Policy:** The ISP proxy network is designed for activities falling within the legal framework of all jurisdictions. Requests targeting high-risk, offensive, harmful, or illegal content may be blocked.
+- **Content Policy:** The ISP proxy network is designed for activities falling within the legal framework of all jurisdictions. Requests targeting high-risk, offensive, harmful, or illegal content may be blocked. See [Blocked Destination Categories](https://www.joinmassive.com/blocked-destinations) for the specific categories.
 
 Requests blocked due to protocol, port, or content restrictions return a `452 Disallowed Content` error.
 

--- a/kb/faq/how-can-i-request-access-to-restricted-content-for-legitimate-business-needs.mdx
+++ b/kb/faq/how-can-i-request-access-to-restricted-content-for-legitimate-business-needs.mdx
@@ -2,6 +2,8 @@
 title: "How can I request access to restricted content for legitimate business needs?"
 ---
 
+Before you start, check [Blocked Destination Categories](https://www.joinmassive.com/blocked-destinations) to confirm which category applies to your target and which categories are eligible for a waiver.
+
 Follow these steps:
 
 1. Submit a request through our [Massive Help Desk](https://forms.fillout.com/t/p8dRqBYs58us)

--- a/kb/general/what-content-is-restricted-on-the-massive-network.mdx
+++ b/kb/general/what-content-is-restricted-on-the-massive-network.mdx
@@ -8,3 +8,5 @@ The following content types are blocked:
 - Adult or explicit content  
 - Sites facilitating illegal activities
 - Domains associated with evading laws or site Terms of Service (TOS)
+
+This is a summary. See [Blocked Destination Categories](https://www.joinmassive.com/blocked-destinations)

--- a/kb/general/what-content-is-restricted-on-the-massive-network.mdx
+++ b/kb/general/what-content-is-restricted-on-the-massive-network.mdx
@@ -9,4 +9,4 @@ The following content types are blocked:
 - Sites facilitating illegal activities
 - Domains associated with evading laws or site Terms of Service (TOS)
 
-This is a summary. See [Blocked Destination Categories](https://www.joinmassive.com/blocked-destinations)
+This is a summary. See [Blocked Destination Categories](https://www.joinmassive.com/blocked-destinations) for the full list.

--- a/kb/technical/what-are-the-usage-restrictions-for-massive-network-proxies-isp-and-residential.mdx
+++ b/kb/technical/what-are-the-usage-restrictions-for-massive-network-proxies-isp-and-residential.mdx
@@ -18,3 +18,4 @@ Our proxy networks have the following restrictions:
    - Only legal and compliant activities are supported
    - 452 Disallowed Content error will appear for restricted content
    - The network is designed for "family-friendly" content
+   - See [Blocked Destination Categories](https://www.joinmassive.com/blocked-destinations) for the full list of categories blocked at the network layer

--- a/kb/technical/what-are-the-usage-restrictions-for-massive-network-proxies-isp-and-residential.mdx
+++ b/kb/technical/what-are-the-usage-restrictions-for-massive-network-proxies-isp-and-residential.mdx
@@ -18,4 +18,4 @@ Our proxy networks have the following restrictions:
    - Only legal and compliant activities are supported
    - 452 Disallowed Content error will appear for restricted content
    - The network is designed for "family-friendly" content
-   - See [Blocked Destination Categories](https://www.joinmassive.com/blocked-destinations) for the full list of categories blocked at the network layer
+   - See [Blocked Destination Categories](https://www.joinmassive.com/blocked-destinations) for the full list of categories blocked at the network layer.

--- a/residential/domain-blocking.mdx
+++ b/residential/domain-blocking.mdx
@@ -7,6 +7,8 @@ description: "Block specific domains directly from the Massive Dashboard with pe
 
 The Domain Blocklist feature allows users to block specific domains directly from the Massive Dashboard. This provides greater control over browsing restrictions without requiring API calls or admin intervention.
 
+Your blocklist adds to the categories Massive already blocks for every account at the network layer. See [Blocked Destination Categories](https://www.joinmassive.com/blocked-destinations)
+
 ## Key Features
 
 - Add or remove domains to your personal blocklist

--- a/residential/domain-blocking.mdx
+++ b/residential/domain-blocking.mdx
@@ -7,7 +7,7 @@ description: "Block specific domains directly from the Massive Dashboard with pe
 
 The Domain Blocklist feature allows users to block specific domains directly from the Massive Dashboard. This provides greater control over browsing restrictions without requiring API calls or admin intervention.
 
-Your blocklist adds to the categories Massive already blocks for every account at the network layer. See [Blocked Destination Categories](https://www.joinmassive.com/blocked-destinations)
+Your blocklist adds to the categories Massive already blocks for every account at the network layer. See [Blocked Destination Categories](https://www.joinmassive.com/blocked-destinations).
 
 ## Key Features
 

--- a/residential/usage-restrictions.mdx
+++ b/residential/usage-restrictions.mdx
@@ -8,10 +8,16 @@ description: 'Some restrictions apply to the use of both the HTTP(S) and SOCKS5 
 - Ports other than the standard `80` and `443` are blocked; `http://example.com/` and `https://example.com/` are acceptable targets, for example, but `http://example.com:8080` would be rejected.
 - The Massive Network is intended to optimize delivery of content that could be reasonably considered “family friendly” to a (currently) worldwide userbase (in the future, regional distinctions are planned), so potentially dangerous or offensive content isn’t allowed.
 
-A request that’s blocked due to any of these protocol, port, or content restrictions will fail with a `452` Disallowed Content error message.
+A request that’s blocked due to any of these protocol, port, or content restrictions will fail with a `452` Disallowed Content error message. See [Blocked Destination Categories](https://www.joinmassive.com/blocked-destinations) for the specific categories blocked at the network layer.
 
 # Restricted Domains
 - We restrict access to content that is generally used to evade the law or site TOS policies. If you are getting blocked from accessing certain content that you have a legitimate reason to access, then contact support to complete our KYC process to gain access.
+
+<Note>
+  The full set of blocked destination categories, the activity prohibited under our
+  Acceptable Use Policy, and the exception and waiver process are published at
+  [Blocked Destination Categories](https://www.joinmassive.com/blocked-destinations).
+</Note>
 
 # Port 25
 - `Port 25` cannot be opened on our residential proxy network. If you want to use residential proxies to test email sending, you can request access for `Port 587` or `Port 465`.


### PR DESCRIPTION
Add cross-references to https://www.joinmassive.com/blocked-destinations from the content-restriction, usage-restriction, domain-blocking, and restricted-content-access pages so readers can reach the full category list, AUP, and waiver process.