### PR TITLE
Fix sample integrations

### DIFF
--- a/residential/samples/puppeteer.mdx
+++ b/residential/samples/puppeteer.mdx
@@ -14,7 +14,7 @@ const puppeteer = require('puppeteer');
   const page    = (await browser.pages())[0];
 
   await page.authenticate({
-    username: '{PROXY_USERNAME},
+    username: '{PROXY_USERNAME}',
     password: '{API_KEY}'
   });
   await page.goto('https://cloudflare.com/cdn-cgi/trace'); // Insert your target URL here

--- a/residential/samples/python.mdx
+++ b/residential/samples/python.mdx
@@ -3,7 +3,7 @@ title: '(Vanilla) Python'
 description: 'To connect to the Massive Network from Python, include your encoded credentials in the proxy address (this usage doesn’t risk leaking your API token to a shared history file per the caveat for Curl):'
 ---
 
-```javascript
+```python
 #!/usr/bin/env python3
 import requests
 import urllib

--- a/residential/samples/ruby.mdx
+++ b/residential/samples/ruby.mdx
@@ -3,22 +3,21 @@ title: 'Ruby'
 description: 'Ruby’s standard HTTP library doesn’t seem to support HTTPS proxy connections, so connect to the [Massive Network’s HTTP port](/authentication#http) with Ruby:'
 ---
 
-```javascript
-#!/usr/bin/env node
-const puppeteer = require('puppeteer');
+```ruby
+#!/usr/bin/env ruby
+require 'net/http'
+require 'uri'
 
-(async () => {
-  const browser = await puppeteer.launch({
-                    args: ['--proxy-server=https://network.joinmassive.com:65535']
-                  });
-  const page    = (await browser.pages())[0];
+username = '{PROXY_USERNAME}'
+password = '{API_KEY}'
+url      = URI('https://cloudflare.com/cdn-cgi/trace') # Insert your target URL here
+host     = 'network.joinmassive.com'
+port     = 65534
 
-  await page.authenticate({
-    username: '{PROXY_USERNAME},
-    password: '{API_KEY}'
-  });
-  await page.goto('https://cloudflare.com/cdn-cgi/trace'); // Insert your target URL here
-  console.log(await page.content());
-  browser.close();
-})();
+proxy    = Net::HTTP.Proxy(host, port, username, password)
+response = proxy.start(url.host, url.port, use_ssl: url.scheme == 'https') do |http|
+             http.request(Net::HTTP::Get.new(url))
+           end
+
+puts response.body
 ```


### PR DESCRIPTION
The Puppeteer sample has an unterminated string on the `username` line
(`'{PROXY_USERNAME},`). Saving the block and running `node --check` returns
a SyntaxError, so the sample fails on copy-paste.

`residential/samples/ruby.mdx` currently contains the Puppeteer sample
rather than Ruby. The page description explains that Ruby's stdlib doesn't
support HTTPS proxy connections and points to the HTTP port, but the code
connects to 65535. Replaced with a `Net::HTTP.Proxy` sample on port 65534
matching the description.

Also corrected the Python code fence from `javascript` to `python`.