### PR TITLE
docs: raise max sticky session TTL from 240 to 1440 minutes

### DIFF
--- a/kb/technical/what-are-sticky-sessions-and-how-do-they-work.mdx
+++ b/kb/technical/what-are-sticky-sessions-and-how-do-they-work.mdx
@@ -8,7 +8,7 @@ Sticky sessions (session persistence) maintain the same proxy IP for multiple re
 
 1. Duration:
    - Default TTL: 15 minutes
-   - Maximum TTL: 240 minutes (4 hours)
+   - Maximum TTL: 1440 minutes (24 hours)
    - Customizable via `sessionttl` parameter
    - Static TTL: expires at creation time + TTL, not extended by activity
 

--- a/kb/technical/what-is-the-difference-between-sticky-sessions-and-tcp-connections.mdx
+++ b/kb/technical/what-is-the-difference-between-sticky-sessions-and-tcp-connections.mdx
@@ -18,7 +18,7 @@ When a TCP connection closes, it does **not** mean your sticky session has expir
 
 A sticky session is a logical mapping between your session ID and a specific proxy node (IP address). It is tracked server-side and persists independently of TCP connections.
 
-- **Default TTL**: 15 minutes (customizable up to 240 minutes via `sessionttl`)
+- **Default TTL**: 15 minutes (customizable up to 1440 minutes via `sessionttl`)
 - **TTL is static**: Set at creation time, not extended by subsequent requests
 - **Scope**: All requests sharing the same session ID, regardless of how many TCP connections they use
 - **Lifetime**: Minutes to hours, controlled by `sessionttl` parameter.
@@ -55,7 +55,7 @@ Within a single sticky session, many TCP connections can open and close — your
 |---|---|---|
 | **What it is** | Network socket between client and proxy | Logical IP-to-session mapping |
 | **Idle timeout** | 30 seconds | None (static TTL) |
-| **Max lifetime** | As long as data flows | 240 minutes (`sessionttl-240`) |
+| **Max lifetime** | As long as data flows | 1440 minutes (`sessionttl-1440`) |
 
 <Info>
   The 30-second idle timeout applies to the TCP connection, not the session TTL. If your TCP connection closes due to inactivity, simply open a new connection with the same session ID — you will get the same IP as long as the session TTL has not expired.

--- a/residential/sticky-sessions.mdx
+++ b/residential/sticky-sessions.mdx
@@ -8,7 +8,7 @@ description: "We support session persistence (AKA sticky sessions) with a custom
 | Key        | Value                                                                                                                                                                          | TTL                                                    | Examples        |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------ | --------------- |
 | session    | Any unique identifier of up to 255 characters (regardless of character encoding); Massive will make best efforts to route requests in the same session to the same egress node | Default: 15 minutes (customizable with `sessionttl`) | session42, 1234 |
-| sessionttl | Customizable session TTL in minutes, up to 240 minutes                                                                                                                          | Default: 15 minutes                                    | 30, 60, 120, 240 |
+| sessionttl | Customizable session TTL in minutes, up to 1440 minutes                                                                                                                         | Default: 15 minutes                                    | 30, 60, 240, 1440 |
 
 You can inject a session identifier, like a unique representation of your app or active task, to specify that multiple requests should originate from a single egress node (if available):
 
@@ -20,7 +20,7 @@ curl -x https://network.joinmassive.com:65535 \
 
 ### Session TTL Behavior
 
-* Session TTL defaults to 15 minutes but can be customized using the `sessionttl` parameter up to 240 minutes (4 hours).
+* Session TTL defaults to 15 minutes but can be customized using the `sessionttl` parameter up to 1440 minutes (24 hours).
 * **Important**: Sessions use static TTL - they expire at creation time + TTL and are not extended by subsequent requests.
 * For example, to set the TTL to 30 minutes:
 


### PR DESCRIPTION
## Summary

The network-wide maximum sticky session TTL was raised from 240 to 1440 minutes; 

- `residential/sticky-sessions.mdx`: `sessionttl` parameter table (max + examples) and Session TTL Behavior section now state 1440 minutes (24 hours)
- `kb/technical/what-are-sticky-sessions-and-how-do-they-work.mdx`: maximum TTL updated to 1440 minutes (24 hours)
- `kb/technical/what-is-the-difference-between-sticky-sessions-and-tcp-connections.mdx`: default-TTL note and max-lifetime comparison table updated to 1440 (`sessionttl-1440`)

No behavior change on the network side; docs catch-up only.