### PR TITLE
docs(reporting-api): clarify `to` semantics, used_bytes units, and data freshness

### DIFF
--- a/reporting-api-reference/Massive-Proxy-Reporting-API-v1.yaml
+++ b/reporting-api-reference/Massive-Proxy-Reporting-API-v1.yaml
@@ -17,6 +17,8 @@ paths:
         Get usage data for the given time range.
 
         If no time range is provided, returns usage for the past 7 days (including today).
+
+        Usage is aggregated hourly — see [Data freshness](/reporting-api-reference/reporting-api#data-freshness) before scheduling reporting jobs.
       operationId: getUsage
       security:
         - ApiKeyAuth: []
@@ -39,11 +41,13 @@ paths:
             type: string
           required: false
           description: |
-            End data to query usage (UTC).
+            End date/time to query usage (UTC).
 
-            Must be greater than 'from' date.
+            Accepted formats: date (`2025-01-01`) or RFC3339 (`2025-01-01T10:00:00Z`).
 
-            Accepted formats: date, RFC3339.
+            Must be greater than 'from'.
+
+            Usage is aggregated in hourly buckets, and the range **includes the hourly bucket containing** `to`. A date-only value is interpreted as midnight UTC (00:00:00), so it returns only the first hour of that day — to include a full final day, pass `to=YYYY-MM-DDT23:59:59Z`.
           example: "2025-01-01 or 2025-01-01T10:00:00Z"
       responses:
         "200":
@@ -85,7 +89,10 @@ components:
           example: 500
         used_bytes:
           type: number
-          description: The number of used bytes
+          description: |
+            Bytes consumed (raw bytes).
+
+            To convert to GB as shown in the dashboard, divide by 10⁹ (decimal GB, not 2³⁰).
           example: 123456789
     Error:
       type: object

--- a/reporting-api-reference/reporting-api.mdx
+++ b/reporting-api-reference/reporting-api.mdx
@@ -19,3 +19,11 @@ curl --location 'https://api-network.joinmassive.com/reporting/v1/usage' \
 --header 'Content-Type: application/json' \
 --header 'x-api-key: {PROXY_PASSWORD}'
 ```
+
+# Data freshness
+
+Usage data is aggregated hourly, a few minutes after each hour completes. A calendar day (UTC) is final approximately 15 minutes after midnight UTC, once its last hour is aggregated. For daily reporting jobs, query after 00:30 UTC with `to=YYYY-MM-DDT23:59:59Z`.
+
+<Note>
+  Usage is recorded when a connection closes, so a session that crosses midnight counts toward the day in which it ends.
+</Note>


### PR DESCRIPTION
Closes the three Reporting API documentation gaps confirmed in [SUP-1368](https://linear.app/joinmassive/issue/SUP-1368) (origin: [SUP-1308](https://linear.app/joinmassive/issue/SUP-1308), Datamam). Wording is the engineering-verified text from the issue.

## Changes

**`to` parameter** ([Get usage](https://docs.joinmassive.com/reporting-api-reference/get-usage)) — documents that the range includes the hourly bucket containing `to`, and that a date-only value means midnight UTC, so it returns only the first hour of that day. Points at `to=YYYY-MM-DDT23:59:59Z` for a full final day. Also fixes the pre-existing "End **data** to query usage" typo.

**`used_bytes` field** — raw bytes; divide by 10⁹ for the decimal GB shown in the dashboard.

**New "Data freshness" section** ([Reporting API overview](https://docs.joinmassive.com/reporting-api-reference/reporting-api)) — hourly aggregation, a UTC day being final ~15 min after midnight, guidance to run daily jobs after 00:30 UTC, and the caveat that usage is recorded on connection close so midnight-crossing sessions count toward the day they end in.

The freshness note lives on the overview page because the Get usage page is generated entirely from the OpenAPI spec and has no body content; the endpoint description links to it.

## Note

If [PROXY-402](https://linear.app/joinmassive/issue/PROXY-402) (date-only `to` → end of day) ships, the `to` description will need a small revision — this documents current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)