### PR TITLE
docs(residential): document multi-value geo and ASN targeting

### DIFF
--- a/residential/asn-type-targeting.mdx
+++ b/residential/asn-type-targeting.mdx
@@ -22,3 +22,15 @@ curl -x https://network.joinmassive.com:65535 \
      -U '{PROXY_USERNAME}-country-US-asn-7018:{API_KEY}' \
      https://cloudflare.com/cdn-cgi/trace
 ```
+
+## Multiple ASNs
+
+`asn` accepts a comma-separated list of up to **5** values. The request is served by a node on any of the listed networks:
+
+```bash
+curl -x https://network.joinmassive.com:65535 \
+     -U '{PROXY_USERNAME}-country-US-asn-7018,7922:{API_KEY}' \
+     https://cloudflare.com/cdn-cgi/trace
+```
+
+Only one parameter may hold a list per request, so a list of ASNs requires the other parameters (such as `country`) to be single-valued. A single `asn` can still be combined with [multiple countries](/residential/geotargeting#targeting-multiple-locations).

--- a/residential/geotargeting.mdx
+++ b/residential/geotargeting.mdx
@@ -31,6 +31,42 @@ curl -x https://network.joinmassive.com:65535 \
 
 _Please, take into account, that due to technical reasons, the more strict geotargeting narrows the range of appropriate nodes._
 
+## Targeting multiple locations
+
+Each of `country`, `subdivision`, `city`, and `zipcode` accepts a comma-separated list of up to **5** values. The request is then served by any node that matches one of the listed values, and traffic is spread across them.
+
+```bash
+curl -x https://network.joinmassive.com:65535 \
+     -U '{PROXY_USERNAME}-country-US,GB,DE:{API_KEY}' \
+     https://cloudflare.com/cdn-cgi/trace
+```
+
+### Rules for multiple values
+
+- **One list per request.** Only one parameter may hold a list. Passing a list in two parameters at once (for example several countries _and_ several cities) returns HTTP 400.
+- **A list of countries can't be narrowed.** When `country` holds more than one value, `subdivision`, `city`, and `zipcode` may not be used, because the same region or city name can exist in more than one country. A single `asn` can still be combined with multiple countries.
+- **`country` is still required** whenever any geo parameter is set.
+- **Up to 5 values** per parameter. More than 5 returns HTTP 400.
+- Duplicate and empty values are ignored — `US,US` counts as a single value.
+
+### Examples
+
+Multiple countries:
+
+```bash
+curl -x https://network.joinmassive.com:65535 \
+     -U '{PROXY_USERNAME}-country-US,GB,DE:{API_KEY}' \
+     https://cloudflare.com/cdn-cgi/trace
+```
+
+A single country, multiple cities:
+
+```bash
+curl -x https://network.joinmassive.com:65535 \
+     -U '{PROXY_USERNAME}-country-US-city-New%20York,Chicago:{API_KEY}' \
+     https://cloudflare.com/cdn-cgi/trace
+```
+
 ## Zipcode Notes
 
 For the following countries, we accept partial postal codes with the number of characters indicated below:


### PR DESCRIPTION
## What

Documents the multi-value geo targeting feature (PROXY-366): `country`, `subdivision`, `city`, `zipcode` and `asn` credential parameters now each accept a comma-separated list of up to **5** values.

## Changes

- **`residential/geotargeting.mdx`** — new **Targeting multiple locations** section:
  - comma-separated list (up to 5) per parameter; request served by any node matching one of the listed values
  - rules: one list per request; a list of countries can't be narrowed by `subdivision`/`city`/`zipcode`; `country` still required; >5 values → HTTP 400; duplicates/empties ignored
  - examples (multiple countries; one country + multiple cities)
- **`residential/asn-type-targeting.mdx`** — new **Multiple ASNs** section: `asn` accepts a list of up to 5; only one parameter may hold a list; a single `asn` can be combined with multiple countries

## Notes

Customer-facing only — internal routing/rollout details are intentionally excluded. Tone and format match the existing residential pages.